### PR TITLE
To Master - User can delete playlist

### DIFF
--- a/models/playlists.js
+++ b/models/playlists.js
@@ -3,23 +3,22 @@ const configuration = require('../knexfile')[environment];
 const database = require('knex')(configuration);
 
 class Playlists {
-  // constructor(){
-  // }
+  constructor(){
+  }
 
   async allPlaylists() {
     return database('playlists')
       .select();
   }
 //
-//   async findFavorite(favoriteId) {
-//     return database('favorites')
-//       .where('id', favoriteId)
-//       .columns('id', 'title', 'artistName', 'genre', 'rating');
-//   }
+  async findPlaylist(playlistId) {
+    return database('playlists')
+      .where('id', playlistId);
+  }
 //
-//   async deleteFavorite(songID) {
-//     return database('favorites').where('id', songID).del()
-//   }
+  async deletePlaylist(playlistId) {
+    return database('playlists').where('id', playlistId).del()
+  }
 //
 //   async createFavorite(trackObject){
 //    return database('favorites')

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -33,22 +33,22 @@ router.get('/', async function (request, response) {
 //   }
 // });
 //
-// router.delete('/:id', async function (request, response) {
-//
-//   try {
-//     let favoriteId = await request.params.id
-//     let data = await favorites.findFavorite(favoriteId)
-//     if (data.length != 0){
-//       await favorites.deleteFavorite(data[0].id)
-//       return response.status(204).json(data);
-//     } else {
-//       return response.status(404).json({"error": "Record not found"});
-//     }
-//   }
-//   catch(error) {
-//     return response.status(500).json({"error": "Request could not be handled"});
-//   }
-// });
+router.delete('/:id', async function (request, response) {
+
+  try {
+    let playlistId = await request.params.id
+    let data = await favorites.findPlaylist(playlistId)
+    if (data.length != 0){
+      await playlists.deletePlaylist(data[0].id)
+      return response.status(204).json(data);
+    } else {
+      return response.status(404).json({"error": "Record not found"});
+    }
+  }
+  catch(error) {
+    return response.status(500).json({"error": "Request could not be handled"});
+  }
+});
 //
 // router.post('/', async function (request, response) {
 //   try {

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -37,7 +37,8 @@ router.delete('/:id', async function (request, response) {
 
   try {
     let playlistId = await request.params.id
-    let data = await favorites.findPlaylist(playlistId)
+    let data = await playlists.findPlaylist(playlistId)
+
     if (data.length != 0){
       await playlists.deletePlaylist(data[0].id)
       return response.status(204).json(data);

--- a/tests/delete_playlist.spec.js
+++ b/tests/delete_playlist.spec.js
@@ -1,0 +1,57 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('test playlists path', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists cascade');
+
+    await database('playlists').insert([
+      {title: '80s Rock', id: 1},
+      {title: 'Chill Mix', id: 2},
+      {title: 'Jazz Playlist', id: 3},
+      {title: 'EDM Playlist', id: 4}
+    ]);
+  });
+
+  afterEach(() => {
+    database.raw('truncate table playlists cascade');
+  });
+
+  describe('test playlist DELETE', () => {
+    it('happy path', async () => {
+      const response = await request(app)
+        .delete("/api/v1/playlists/2");
+
+      expect(response.statusCode).toBe(204);
+      expect(await database('playlists').where('id', 2).select()).toEqual([]);
+      expect(await database('playlists').where('title','Chill Mix').select()).toEqual([]);
+    });
+
+    it('sad path', async () => {
+      const response = await request(app)
+        .delete("/api/v1/playlists/2");
+
+      expect(response.statusCode).toBe(204);
+      expect(await database('playlists').where('id', 2).select()).toEqual([]);
+
+      const response2 = await request(app)
+        .delete("/api/v1/playlists/2");
+
+      expect(response2.statusCode).toBe(404);
+
+      expect(response2.body).toStrictEqual({"error": "Record not found"});
+
+      const response3 = await request(app)
+        .delete("/api/v1/playlists/chicken");
+
+      expect(response3.statusCode).toBe(500);
+
+      expect(response3.body).toStrictEqual({"error": "Request could not be handled"});
+    });
+  });
+});


### PR DESCRIPTION
## Issue Number: #22 

### Description of Behavior

User can delete playlist by playlist ID. User can make DELETE request to `api/v1/playlists/:id`. If record is found, record is deleted and 204 status response is returned. If record not found, 404 status code is returned. 500 error used as catch error. 

### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests are written
- [x] Test coverage acceptable
- [x] Sad paths accounted for
- [x] Tested in browser 


### Merge to
- [ ] Development branch
- [ ] Staging branch
- [x] Master

### Additional Comments

Used following code to test that record was deleted 
```
 expect(await database('playlists').where('id', 2).select()).toEqual([]); 
```

Might be handy for future test!
