### PR TITLE
To Master - User can update a playlist

### DIFF
--- a/models/playlists.js
+++ b/models/playlists.js
@@ -10,6 +10,13 @@ class Playlists {
     return database('playlists')
       .select();
   }
+
+  async updatePlaylist(id, new_title) {
+    return database('playlists')
+      .where('id', id)
+      .update({ title: new_title })
+      .returning(['id', 'title', 'created_at', 'updated_at']);
+  }
 //
   async findPlaylist(playlistId) {
     return database('playlists')

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -18,13 +18,12 @@ router.get('/', async function (request, response) {
 });
 //
 router.put('/:id', async function (request, response) {
-    let playlistId = await request.params.id
-    let title = await request.body.title
-    console.log(playlistId, title)
+  let playlistId = await request.params.id
+  let title = await request.body.title
 
-  let object = playlists.findPlaylist(playlistId)
+  let object = await playlists.findPlaylist(playlistId)
 
-  if (object.length != 0) {
+  if (object.length == 0) {
     return response.status(400).json({"error": "Please enter a valid id"});
   }
 
@@ -43,7 +42,6 @@ router.put('/:id', async function (request, response) {
       return response.status(400).json({"error": "Please enter a unique title"});
     }
   }
-
   catch(error) {
     return response.status(500).json({"error": "Request could not be handled"});
   }

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -17,21 +17,37 @@ router.get('/', async function (request, response) {
    });
 });
 //
-// router.get('/:id', async function (request, response) {
-//   try {
-//     let favoriteId = await request.params.id
-//     let data = await favorites.findFavorite(favoriteId)
-//
-//     if (data.length != 0){
-//       return response.status(200).json(data);
-//     } else {
-//       return response.status(404).json({"error": "Record not found"});
-//     }
-//   }
-//   catch(error) {
-//     return response.status(500).json({ "error": "Unable to handle request" });
-//   }
-// });
+router.put('/:id', async function (request, response) {
+    let playlistId = await request.params.id
+    let title = await request.body.title
+    console.log(playlistId, title)
+
+  let object = playlists.findPlaylist(playlistId)
+
+  if (object.length != 0) {
+    return response.status(400).json({"error": "Please enter a valid id"});
+  }
+
+  try {
+    if (!('title' in request.body)) {
+      return response.status(400).json({"error": "You must include a title parameter in the request"});
+    }
+    if (request.body.title === '') {
+      return response.status(400).json({"error": "Title cannot be blank"});
+    }
+    try {
+      let data = await playlists.updatePlaylist(playlistId, title)
+      return response.status(200).json(data)
+    }
+    catch(error) {
+      return response.status(400).json({"error": "Please enter a unique title"});
+    }
+  }
+
+  catch(error) {
+    return response.status(500).json({"error": "Request could not be handled"});
+  }
+});
 //
 router.delete('/:id', async function (request, response) {
 

--- a/tests/post_playlists.spec.js
+++ b/tests/post_playlists.spec.js
@@ -11,7 +11,7 @@ describe('test playlists POST', () => {
 
   it('user can create a playlist', async () => {
     let body = {
-      title: "Punk Rock Playlist"
+      title: "Chicken Dance Party"
     };
     let response = await request(app)
       .post("/api/v1/playlists")
@@ -24,24 +24,24 @@ describe('test playlists POST', () => {
     expect(response.body[0]).toHaveProperty('created_at');
     expect(response.body[0]).toHaveProperty('updated_at');
 
-    expect(response.body[0].title).toBe('Punk Rock Playlist');
+    expect(response.body[0].title).toBe('Chicken Dance Party');
 
     let lastCreatedPlaylist = await database('playlists').orderBy('created_at', 'desc').first()
 
-    expect(lastCreatedPlaylist.title).toBe('Punk Rock Playlist');
+    expect(lastCreatedPlaylist.title).toBe('Chicken Dance Party');
 
   });
 
   it('user cannot create playlist with the same title', async () => {
     let body = {
-      title: "Punk Rock Playlist"
+      title: "Chicken Dance Party"
     };
     await request(app)
       .post("/api/v1/playlists")
       .send(body);
 
       let body2 = {
-        title: "Punk Rock Playlist"
+        title: "Chicken Dance Party"
       };
       let response = await request(app)
         .post("/api/v1/playlists")

--- a/tests/post_playlists.spec.js
+++ b/tests/post_playlists.spec.js
@@ -8,7 +8,13 @@ const database = require('knex')(configuration);
 
 
 describe('test playlists POST', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists cascade');
+  });
 
+  afterEach(() => {
+    database.raw('truncate table playlists cascade');
+  });
   it('user can create a playlist', async () => {
     let body = {
       title: "Chicken Dance Party"

--- a/tests/put_playlist.spec.js
+++ b/tests/put_playlist.spec.js
@@ -1,0 +1,100 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+
+describe('test playlists PUT', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists cascade');
+
+    await database('playlists').insert([
+      {title: '80s Rock', id: 1},
+      {title: 'Chill Mix', id: 2},
+      {title: 'Jazz Playlist', id: 3},
+      {title: 'EDM Playlist', id: 4}
+    ]);
+  });
+
+  afterEach(() => {
+    database.raw('truncate table playlists cascade');
+  });
+
+  it('user can update a playlist', async () => {
+    console.log(database('playlists').where({ id: 1}).select())
+    let body = {
+      title: "Punk Rock Playlist"
+    };
+    let response = await request(app)
+      .put("/api/v1/playlists/1")
+      .send(body);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body[0]).toHaveProperty('title');
+    expect(response.body[0]).toHaveProperty('id');
+    expect(response.body[0]).toHaveProperty('created_at');
+    expect(response.body[0]).toHaveProperty('updated_at');
+
+    expect(response.body[0].title).toBe('Punk Rock Playlist');
+
+    let playlist = await database('playlists').where({ id: 1})
+
+    expect(playlist.title).toBe('Punk Rock Playlist');
+
+  });
+
+  it('user cannot update playlist with the same title', async () => {
+    let body = {
+      title: "Punk Rock Playlist"
+    };
+    await request(app)
+      .put("/api/v1/playlists/1")
+      .send(body);
+
+      let body2 = {
+        title: "Punk Rock Playlist"
+      };
+      let response = await request(app)
+        .post("/api/v1/playlists")
+        .send(body2);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body.error).toBe('Please enter a unique title');
+  });
+
+  it('user cannot update playlist without including title in body or request', async () => {
+    let body = {
+      titl: "Elevator Jazz Playlist"
+    };
+    let response = await request(app)
+      .put("/api/v1/playlists/1")
+      .send(body);
+    expect(response.statusCode).toBe(400);
+    expect(response.body.error).toBe('You must include a title parameter in the request');
+  });
+
+  it('user cannot update playlist with blank title in body or request', async () => {
+    let body = {
+      title: ""
+    };
+    let response = await request(app)
+      .put("/api/v1/playlists/1")
+      .send(body);
+    expect(response.statusCode).toBe(400);
+    expect(response.body.error).toBe('Title cannot be blank');
+  });
+
+  it('user cannot update playlist with blank title in body or request', async () => {
+    let body = {
+      title: ""
+    };
+    let response = await request(app)
+      .put("/api/v1/playlists/100000")
+      .send(body);
+    expect(response.statusCode).toBe(400);
+    expect(response.body.error).toBe('Please enter a valid id');
+  });
+});

--- a/tests/put_playlist.spec.js
+++ b/tests/put_playlist.spec.js
@@ -6,7 +6,6 @@ const environment = process.env.NODE_ENV || 'test';
 const configuration = require('../knexfile')[environment];
 const database = require('knex')(configuration);
 
-
 describe('test playlists PUT', () => {
   beforeEach(async () => {
     await database.raw('truncate table playlists cascade');
@@ -24,7 +23,6 @@ describe('test playlists PUT', () => {
   });
 
   it('user can update a playlist', async () => {
-    console.log(database('playlists').where({ id: 1}).select())
     let body = {
       title: "Punk Rock Playlist"
     };
@@ -38,12 +36,10 @@ describe('test playlists PUT', () => {
     expect(response.body[0]).toHaveProperty('created_at');
     expect(response.body[0]).toHaveProperty('updated_at');
 
-    expect(response.body[0].title).toBe('Punk Rock Playlist');
+    expect(response.body[0].title).toEqual('Punk Rock Playlist');
 
     let playlist = await database('playlists').where({ id: 1})
-
-    expect(playlist.title).toBe('Punk Rock Playlist');
-
+    expect(playlist[0].title).toEqual('Punk Rock Playlist');
   });
 
   it('user cannot update playlist with the same title', async () => {
@@ -61,8 +57,8 @@ describe('test playlists PUT', () => {
         .post("/api/v1/playlists")
         .send(body2);
 
-    expect(response.statusCode).toBe(400);
-    expect(response.body.error).toBe('Please enter a unique title');
+    expect(response.statusCode).toEqual(400);
+    expect(response.body.error).toEqual('Please enter a unique title');
   });
 
   it('user cannot update playlist without including title in body or request', async () => {
@@ -72,8 +68,8 @@ describe('test playlists PUT', () => {
     let response = await request(app)
       .put("/api/v1/playlists/1")
       .send(body);
-    expect(response.statusCode).toBe(400);
-    expect(response.body.error).toBe('You must include a title parameter in the request');
+    expect(response.statusCode).toEqual(400);
+    expect(response.body.error).toEqual('You must include a title parameter in the request');
   });
 
   it('user cannot update playlist with blank title in body or request', async () => {
@@ -83,8 +79,8 @@ describe('test playlists PUT', () => {
     let response = await request(app)
       .put("/api/v1/playlists/1")
       .send(body);
-    expect(response.statusCode).toBe(400);
-    expect(response.body.error).toBe('Title cannot be blank');
+    expect(response.statusCode).toEqual(400);
+    expect(response.body.error).toEqual('Title cannot be blank');
   });
 
   it('user cannot update playlist with blank title in body or request', async () => {
@@ -94,7 +90,7 @@ describe('test playlists PUT', () => {
     let response = await request(app)
       .put("/api/v1/playlists/100000")
       .send(body);
-    expect(response.statusCode).toBe(400);
-    expect(response.body.error).toBe('Please enter a valid id');
+    expect(response.statusCode).toEqual(400);
+    expect(response.body.error).toEqual('Please enter a valid id');
   });
 });


### PR DESCRIPTION


## Issue Number: #21 

### Description of Behavior

User can update a playlist. User can make PUT request to `api/v1/playlist/:id`. Playlist to be updated is found by ID in the URI. Error handling for if the new title is not included in the body and if ID is not found. 

### Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests are written
- [x] Test coverage acceptable
- [x] Sad paths accounted for
- [x] Tested in browser 


### Merge to
- [ ] Development branch
- [ ] Staging branch
- [X] Master

### Additional Comments



